### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libbpf (0.0.8-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 06:42:39 +0000
+
 libbpf (0.0.8-1) unstable; urgency=medium
 
   * Update from upstream v0.0.8

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/libbpf/libbpf/issues
+Bug-Submit: https://github.com/libbpf/libbpf/issues/new
+Repository: https://github.com/libbpf/libbpf.git
+Repository-Browse: https://github.com/libbpf/libbpf


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/libbpf/65cde17a-5e6e-4457-9f7f-0caa92c8d435.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package libbpf-dev: lines which differ (wdiff format)
* Depends: libbpf0 (= [-1:0.0.8-1~jan+unchanged1)-] {+1:0.0.8-2~jan+lint1)+}
* Source: libbpf [-(0.0.8-1~jan+unchanged1)-] {+(0.0.8-2~jan+lint1)+}
### Control files of package libbpf0: lines which differ (wdiff format)
* Source: libbpf [-(0.0.8-1~jan+unchanged1)-] {+(0.0.8-2~jan+lint1)+}
### Control files of package libbpf0-dbgsym: lines which differ (wdiff format)
* Depends: libbpf0 (= [-1:0.0.8-1~jan+unchanged1)-] {+1:0.0.8-2~jan+lint1)+}
* Source: libbpf [-(0.0.8-1~jan+unchanged1)-] {+(0.0.8-2~jan+lint1)+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/65cde17a-5e6e-4457-9f7f-0caa92c8d435/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/65cde17a-5e6e-4457-9f7f-0caa92c8d435/diffoscope)).
